### PR TITLE
Little improvements

### DIFF
--- a/lib/tuftemark/blockquotes.ex
+++ b/lib/tuftemark/blockquotes.ex
@@ -8,11 +8,11 @@ defmodule Tuftemark.Blockquotes do
   end
 
   defp find_and_replace({"blockquote", attrs, children, annotations} = item, acc) do
-    case Enum.find(attrs, &(elem(&1, 0) == "cite" || elem(&1, 0) == "role")) do
+    case Enum.find(attrs, &(elem(&1, 0) == "cite" || elem(&1, 0) == "class")) do
       {"cite", href} ->
         {citation(href, attrs, children, annotations), acc}
 
-      {"role", "epigraph"} ->
+      {"class", "epigraph"} ->
         {epigraph(attrs, children, annotations), acc}
 
       _otherwise ->
@@ -43,7 +43,7 @@ defmodule Tuftemark.Blockquotes do
     {"p", _, footer_content, _} = hd(reversed_children)
     footer = {"footer", [], footer_content, %{}}
 
-    new_attrs = Enum.reject(attrs, &(elem(&1, 0) == "role"))
+    new_attrs = Enum.reject(attrs, &(elem(&1, 0) == "class"))
     new_children = Enum.reverse([footer | tl(reversed_children)])
 
     blockquote = {"blockquote", new_attrs, new_children, annotations}

--- a/lib/tuftemark/sidenotes.ex
+++ b/lib/tuftemark/sidenotes.ex
@@ -2,40 +2,54 @@ defmodule Tuftemark.Sidenotes do
   alias Earmark.{Restructure, Transform}
   alias Tuftemark.Utils
 
-  @foonote_prefix ~r/\[\^(.+)\]/
+  @parse_ex ~r/^\[\^(.*?)\]: (.*)/
+  @split_ex ~r/\[\^(.*?)\]/
 
   def process(ast) do
-    with {cleaner_ast, footnotes} <- find_and_clean(ast),
-         converted_footnotes <- convert(footnotes) do
-      modify(cleaner_ast, converted_footnotes)
+    with {cleaner_ast, footnotes} <- find_footnotes(ast),
+         sidenotes <- to_sidenotes(footnotes) do
+      expand_footnotes(cleaner_ast, sidenotes)
     end
   end
 
-  # Collect all paragraph-footnotes and remove them from the original AST
-  defp find_and_clean(ast) do
+  # Collects all footnote-paragraphs and removes them from the original AST
+  defp find_footnotes(ast) do
     Restructure.walk_and_modify_ast(ast, %{}, fn
-      {"p", _, children, _} = node, acc ->
-        # some paragraphs start not with a text, but with an image or other tag
-        # this is not what we're looking for here, we need only: `[^note]: ...`
+      {_, _, children, _} = node, footnotes_acc when children != [] ->
+        # Some paragraphs start not with a text, but with an image or other tag
+        # this is not what we're looking for here, we need only: `[^note]: ...`.
+        #
+        # So, (1) we take the first element and (2) check if it's a string, then
+        # (3) we try to parse this piece of text; (4) if it can be parsed into
+        # two parts, then it's likely a beginning of a footnote - we grab its
+        # key and content (cleaned from the key).
+        #
+        # Then we re-combine all the details.
+        #
+        # If anything goes wrong: skip it and continue...
         with maybe_text <- hd(children),
              true <- is_binary(maybe_text),
-             [note_id, note_clean] <-
-               Regex.run(~r/^\[\^(.+)\]: (.*)/, maybe_text, capture: :all_but_first) do
-          new_children = List.update_at(children, 0, fn _ -> note_clean end)
-          new_node = put_elem(node, 2, new_children)
+             [key, content] <- parse_footnote(hd(children)) do
+          footnote_children = [content | tl(children)]
+          footnote = put_elem(node, 2, footnote_children)
 
-          {[], Map.put(acc, note_id, new_node)}
+          {[], Map.put(footnotes_acc, key, footnote)}
         else
-          _ -> {node, acc}
+          _ ->
+            {node, footnotes_acc}
         end
 
-      node, acc ->
-        {node, acc}
+      node, footnotes_acc ->
+        {node, footnotes_acc}
     end)
   end
 
-  # Convert footnote's layout (likely, from a `p` tag into set of three tags)
-  defp convert(footnotes) do
+  # - Does it look like "[^note]: Lorem ipsum..."? Let's figure this out!
+  defp parse_footnote(text),
+    do: Regex.run(@parse_ex, text, capture: :all_but_first)
+
+  # Converts footnote's layout into set of three tags
+  defp to_sidenotes(footnotes) do
     footnotes
     |> Enum.map(fn {key, {_, attrs, children, meta}} ->
       is_numbered = String.starts_with?(key, "-")
@@ -43,34 +57,48 @@ defmodule Tuftemark.Sidenotes do
 
       {key, sidenote}
     end)
-    |> Enum.into(%{})
+    |> Map.new()
   end
 
-  # Eventually, we can postprocess previously cleaned AST, find footnotes inside
-  # its nodes and replace them with ones from the map of converted footnotes.
-  defp modify(cleaner_ast, footnotes_found) do
-    Transform.map_ast(cleaner_ast, fn
-      node when is_binary(node) ->
-        if String.match?(node, @foonote_prefix) do
-          node
-          |> String.split(@foonote_prefix, include_captures: true)
-          |> Enum.map(fn piece ->
-            case Regex.run(@foonote_prefix, piece, capture: :all_but_first) do
-              [footnote_key] ->
-                # if we cannot find a footnote in the given map (due to a
-                # possible TYPO), we won't replace it and leave as is
-                Map.get(footnotes_found, footnote_key, piece)
+  # Eventually, we can process the previously cleaned AST, search for footnotes'
+  # anchors inside the text nodes and replace them with elements from the stash
+  # of the prepared sidenotes.
+  #
+  # We look into non-string nodes (the `true` last argument of the `map_ast/3`)
+  # to avoid the issue when may get nested lists (`[[...]]`) for children. By
+  # the way, that is why we `flatten` the resulting list of node's children in
+  # the `maybe_expand/2` function.
 
-              _otherwise ->
-                piece
-            end
-          end)
-        else
-          node
-        end
+  defp expand_footnotes(cleaner_ast, sidenotes),
+    do: Transform.map_ast(cleaner_ast, &maybe_expand(&1, sidenotes), true)
 
-      node ->
-        node
-    end)
+  defp maybe_expand({tag, attrs, children, meta}, sidenotes) do
+    new_children =
+      children
+      |> Enum.map(fn
+        node when is_binary(node) ->
+          node
+          |> String.split(@split_ex, include_captures: true)
+          |> Enum.map(&maybe_replace(&1, sidenotes))
+
+        node ->
+          node
+      end)
+      |> List.flatten()
+
+    {:replace, {tag, attrs, new_children, meta}}
+  end
+
+  # Here we attempt to clean the sidenote key from what we got after splitting:
+  # if we can parse "lorem-ipsum" from the given "[^lorem-ipsum]" then we try to
+  # replace this piece with a sidenote elements, or skip trying...
+  defp maybe_replace(piece, sidenotes) do
+    case Regex.run(@split_ex, piece, capture: :all_but_first) do
+      [sidenote_key] ->
+        Map.get(sidenotes, sidenote_key, sidenote_key)
+
+      _otherwise ->
+        piece
+    end
   end
 end

--- a/lib/tuftemark/sidenotes.ex
+++ b/lib/tuftemark/sidenotes.ex
@@ -2,6 +2,8 @@ defmodule Tuftemark.Sidenotes do
   alias Earmark.{Restructure, Transform}
   alias Tuftemark.Utils
 
+  @foonote_prefix ~r/\[\^(.+)\]/
+
   def process(ast) do
     with {cleaner_ast, footnotes} <- find_and_clean(ast),
          converted_footnotes <- convert(footnotes) do
@@ -12,7 +14,7 @@ defmodule Tuftemark.Sidenotes do
   # Collect all paragraph-footnotes and remove them from the original AST
   defp find_and_clean(ast) do
     Restructure.walk_and_modify_ast(ast, %{}, fn
-      {"p", _, children, _} = item, acc ->
+      {"p", _, children, _} = node, acc ->
         # some paragraphs start not with a text, but with an image or other tag
         # this is not what we're looking for here, we need only: `[^note]: ...`
         with maybe_text <- hd(children),
@@ -20,51 +22,55 @@ defmodule Tuftemark.Sidenotes do
              [note_id, note_clean] <-
                Regex.run(~r/^\[\^(.+)\]: (.*)/, maybe_text, capture: :all_but_first) do
           new_children = List.update_at(children, 0, fn _ -> note_clean end)
-          new_item = put_elem(item, 2, new_children)
+          new_node = put_elem(node, 2, new_children)
 
-          {[], Map.put(acc, note_id, new_item)}
+          {[], Map.put(acc, note_id, new_node)}
         else
-          _ -> {item, acc}
+          _ -> {node, acc}
         end
 
-      item, acc ->
-        {item, acc}
+      node, acc ->
+        {node, acc}
     end)
   end
 
   # Convert footnote's layout (likely, from a `p` tag into set of three tags)
   defp convert(footnotes) do
     footnotes
-    |> Enum.map(fn {key, {_, attrs, children, annotations}} ->
+    |> Enum.map(fn {key, {_, attrs, children, meta}} ->
       is_numbered = String.starts_with?(key, "-")
-      sidenote = Utils.sidenote(key, attrs, children, annotations, is_numbered)
+      sidenote = Utils.sidenote(key, attrs, children, meta, is_numbered)
 
       {key, sidenote}
     end)
     |> Enum.into(%{})
   end
 
-  # Eventually, we can postprocess previously cleaned AST, find footnotes in its items
-  # and replace them with ones from the map of converted footnotes.
+  # Eventually, we can postprocess previously cleaned AST, find footnotes inside
+  # its nodes and replace them with ones from the map of converted footnotes.
   defp modify(cleaner_ast, footnotes_found) do
     Transform.map_ast(cleaner_ast, fn
-      item when is_binary(item) ->
-        item
-        |> String.split(~r/\[\^(.+)\]/, include_captures: true)
-        |> Enum.map(fn piece ->
-          case Regex.run(~r/^\[\^(.+)\]/, piece, capture: :all_but_first) do
-            [footnote_key] ->
-              # if we cannot find a footnote in the given map (due to a
-              # possible TYPO), we won't replace it
-              Map.get(footnotes_found, footnote_key, piece)
+      node when is_binary(node) ->
+        if String.match?(node, @foonote_prefix) do
+          node
+          |> String.split(@foonote_prefix, include_captures: true)
+          |> Enum.map(fn piece ->
+            case Regex.run(@foonote_prefix, piece, capture: :all_but_first) do
+              [footnote_key] ->
+                # if we cannot find a footnote in the given map (due to a
+                # possible TYPO), we won't replace it and leave as is
+                Map.get(footnotes_found, footnote_key, piece)
 
-            _otherwise ->
-              piece
-          end
-        end)
+              _otherwise ->
+                piece
+            end
+          end)
+        else
+          node
+        end
 
-      item ->
-        item
+      node ->
+        node
     end)
   end
 end

--- a/lib/tuftemark/utils.ex
+++ b/lib/tuftemark/utils.ex
@@ -24,7 +24,7 @@ defmodule Tuftemark.Utils do
   The main difference is that for sidenotes we must pass truthy `is_numbered`
   to get automatic numbering for them. Marginal notes shall not be numbered.
   """
-  def sidenote(key, attrs, children, annotations, is_numbered \\ false) do
+  def sidenote(key, attrs, children, meta, is_numbered \\ false) do
     {for_attr, label_class, label_anchor, note_class} =
       if is_numbered do
         {"sn-#{key}", "margin-toggle sidenote-number", "", "sidenote"}
@@ -39,7 +39,7 @@ defmodule Tuftemark.Utils do
       {"input", [{"type", "checkbox"}, {"id", for_attr}, {"class", "margin-toggle"}], [], %{}}
 
     note =
-      {"span", AstTools.merge_atts(attrs, class: note_class), children, annotations}
+      {"span", AstTools.merge_atts(attrs, class: note_class), List.wrap(children), meta}
 
     [label, input, note]
   end

--- a/test/tuftemark_test.exs
+++ b/test/tuftemark_test.exs
@@ -158,12 +158,12 @@ defmodule TuftemarkTest do
     end
 
     # @tag :focus
-    test "converts a blockquote into epigraph when it has such a role" do
+    test "converts a blockquote into epigraph when it has such a class" do
       markdown = """
       > For a successful technology, reality must take precedence over public relations, for Nature cannot be fooled.
       >
       > Richard P. Feynman, _“What Do You Care What Other People Think?”_
-      {:role="epigraph"}
+      {:.epigraph}
       """
 
       expected = """

--- a/test/tuftemark_test.exs
+++ b/test/tuftemark_test.exs
@@ -382,7 +382,7 @@ defmodule TuftemarkTest do
   describe "sidenotes" do
     test "converts ordinary footnotes into marginal notes (without numbering)" do
       markdown = """
-      Dictum vestibulum hac auctor[^hac-auctor] dictumst.
+      **Dictum vestibulum** hac auctor[^hac-auctor] dictumst.
 
       [^hac-auctor]: Pulvinar dui pellentesque amet lacus.
       """
@@ -390,7 +390,7 @@ defmodule TuftemarkTest do
       expected = """
       <article>
         <section>
-          <p>Dictum vestibulum hac auctor<label for="mn-hac-auctor" class="margin-toggle">⊕</label>
+          <p><strong>Dictum vestibulum</strong> hac auctor<label for="mn-hac-auctor" class="margin-toggle">⊕</label>
           <input type="checkbox" id="mn-hac-auctor" class="margin-toggle">
           <span class="marginnote">Pulvinar dui pellentesque amet lacus.</span> dictumst.</p>
         </section>

--- a/test/tuftemark_test.exs
+++ b/test/tuftemark_test.exs
@@ -11,7 +11,6 @@ defmodule TuftemarkTest do
   ##############################################################################
 
   describe "basics, general" do
-    # @tag :focus
     test "wrap whole content in an article tag" do
       markdown = """
       # Lorem
@@ -39,7 +38,6 @@ defmodule TuftemarkTest do
       assert compact_html(expected) == Tuftemark.as_html!(markdown, compact_output: true)
     end
 
-    # @tag :focus
     test "split content into sections around every h2 tag" do
       markdown = """
       # Class vehicula
@@ -78,7 +76,6 @@ defmodule TuftemarkTest do
       assert compact_html(expected) == Tuftemark.as_html!(markdown, compact_output: true)
     end
 
-    # @tag :focus
     test "respects Kramdown syntax for sans class of a paragraph" do
       markdown = """
       If you prefer sans-serifs, use the `sans` class. It relies on Gill Sans, Tufte’s sans-serif font of choice.
@@ -105,7 +102,6 @@ defmodule TuftemarkTest do
   ##############################################################################
 
   describe "blockquotes" do
-    # @tag :focus
     test "converts last p tag to footer+a in a blockquote when a cite attribute set" do
       markdown = """
       > Lorem ipsum sit dolor amet.
@@ -131,7 +127,6 @@ defmodule TuftemarkTest do
       assert compact_html(expected) == Tuftemark.as_html!(markdown, compact_output: true)
     end
 
-    # @tag :focus
     test "adds a footer with link in a blockquote when a cite attribute set and last element is not p tag" do
       markdown = """
       > Per porttitor blandit.
@@ -157,7 +152,6 @@ defmodule TuftemarkTest do
       assert compact_html(expected) == Tuftemark.as_html!(markdown, compact_output: true)
     end
 
-    # @tag :focus
     test "converts a blockquote into epigraph when it has such a class" do
       markdown = """
       > For a successful technology, reality must take precedence over public relations, for Nature cannot be fooled.
@@ -182,7 +176,6 @@ defmodule TuftemarkTest do
       assert compact_html(expected) == Tuftemark.as_html!(markdown, compact_output: true)
     end
 
-    # @tag :focus
     test "leaves blockquote as it is when it's nothing specific" do
       markdown = """
       > Consequat sociosqu aptent nostra.
@@ -210,7 +203,6 @@ defmodule TuftemarkTest do
   ##############################################################################
 
   describe "figures" do
-    @tag :focus
     test "converts regular images by replacing parent `p` tag with the `figure` one" do
       markdown = """
       Fusce sed Lorem.
@@ -235,7 +227,6 @@ defmodule TuftemarkTest do
       assert compact_html(expected) == Tuftemark.as_html!(markdown, compact_output: true)
     end
 
-    @tag :focus
     test "converts fullwidth images when .fullwidth class set to the image" do
       markdown = """
       Nisi laoreet ornare.
@@ -262,7 +253,6 @@ defmodule TuftemarkTest do
     end
 
     # TODO: try to handle captions somehow, maybe to render them in a special way after the image...
-    @tag :focus
     test "converts fullwidth images and ignores caption (as we don't have a place where to put it)" do
       markdown = """
       Elit eget elit habitant.
@@ -291,7 +281,6 @@ defmodule TuftemarkTest do
       assert compact_html(expected) == Tuftemark.as_html!(markdown, compact_output: true)
     end
 
-    @tag :focus
     test "converts regular images with captions into a figure with marginnote layout" do
       markdown = """
       Magnis montes dignissim.
@@ -322,7 +311,6 @@ defmodule TuftemarkTest do
       assert compact_html(expected) == Tuftemark.as_html!(markdown, compact_output: true)
     end
 
-    @tag :focus
     test "converts marginal images with a caption and captures the next usual paragraph of text" do
       markdown = """
       Ante lacus sociosqu litora.
@@ -357,7 +345,6 @@ defmodule TuftemarkTest do
       assert compact_html(expected) == Tuftemark.as_html!(markdown, compact_output: true)
     end
 
-    @tag :focus
     test "converts marginal images without a caption" do
       markdown = """
       Vel sapien ligula senectus.
@@ -393,7 +380,6 @@ defmodule TuftemarkTest do
   ##############################################################################
 
   describe "sidenotes" do
-    # @tag :focus
     test "converts ordinary footnotes into marginal notes (without numbering)" do
       markdown = """
       Dictum vestibulum hac auctor[^hac-auctor] dictumst.
@@ -414,7 +400,6 @@ defmodule TuftemarkTest do
       assert compact_html(expected) == Tuftemark.as_html!(markdown, compact_output: true)
     end
 
-    # @tag :focus
     test "converts special footnotes (dash-prefixed) into sidenotes (with numbering)" do
       markdown = """
       In print, Tufte has used the proprietary Monotype Bembo[^-bembo] font.


### PR DESCRIPTION
Things touched in this request include _(but not limited to)_:

- refactored `Tuftemark.Blockquotes`
- refactored `Tuftemark.Sidenotes`
- rely on the `.epigraph` class instead of `role` for the corresponding blockquote type
- resolved issue with nested lists in the sidenotes processing logic

Technically, the feature set is left untouched (with the `role`/`class` exception).